### PR TITLE
Make instance name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Used by the `server` subcommand
 | http-read-timeout  | `REGISTRY_HTTP_READ_TIMEOUT`  | Timeout duration for HTTP read (default: "10s")              |
 | http-write-timeout | `REGISTRY_HTTP_WRITE_TIMEOUT` | Timeout duration for HTTP write (default: "10s")             |
 | http-max-header    | `REGISTRY_HTTP_MAX_HEADER`    | Maximal HTTP Header size, in bytes. (default: 1MB)           |
+| name               | `REGISTRY_NAME`               | Name of this instance. (default: "K-Link Registry")          |
 | domain             | `REGISTRY_HTTP_DOMAIN`        | Domain used for generation of links (default: "example.com") |
 | base-path          | `REGISTRY_HTTP_BASE_PATH`     | Base path the application is served on (default: "/")        |
 | http-secret        | `REGISTRY_HTTP_SECRET`        | Secret string for session generation (default: generated)    |

--- a/klinkregistry.go
+++ b/klinkregistry.go
@@ -25,6 +25,8 @@ type Emailer interface {
 type Config struct {
 	AssetDir string // use embedded assets if empty
 
+	NetworkName string // Name of the managed Network
+
 	HTTPListen       string
 	HTTPMaxHeader    int
 	HTTPReadTimeout  time.Duration

--- a/klinkregistry/cmd/server.go
+++ b/klinkregistry/cmd/server.go
@@ -42,6 +42,7 @@ configuration by registrants.`,
 			SMTPUser:         viper.GetString("smtp_user"),
 			SMTPPassword:     viper.GetString("smtp_pass"),
 			SMTPFrom:         viper.GetString("smtp_from"),
+			NetworkName:      viper.GetString("name"),
 			AdminUsername:    viper.GetString("admin_username"),
 			AdminPassword:    viper.GetString("admin_password"),
 		}
@@ -91,6 +92,7 @@ func init() {
 	serverCmd.Flags().String("domain", "example.com", "Domain, which will be used for absolute link generation")
 	serverCmd.Flags().String("base-path", "/", "Root path where the web-app will be served, no trailing slash")
 	serverCmd.Flags().String("secret", "", "Secret key for HTTP Sessions")
+	serverCmd.Flags().String("name", "K-Link Registry", "Name of this instance")
 	serverCmd.Flags().String("admin-username", "", "email address of primary admin")
 	serverCmd.Flags().String("admin-password", "", "password of primary admin")
 
@@ -99,6 +101,7 @@ func init() {
 	viper.BindPFlag("http_write_timeout", serverCmd.Flags().Lookup("write-timeout"))
 	viper.BindPFlag("http_max_header", serverCmd.Flags().Lookup("max-header"))
 	viper.BindPFlag("http_base_path", serverCmd.Flags().Lookup("base-path"))
+	viper.BindPFlag("name", serverCmd.Flags().Lookup("name"))
 	viper.BindPFlag("http_domain", serverCmd.Flags().Lookup("domain"))
 	viper.BindPFlag("http_secret", serverCmd.Flags().Lookup("secret"))
 

--- a/router.go
+++ b/router.go
@@ -97,7 +97,7 @@ func (s *Server) initRoutes() {
 			w.Header().Set("x-frame-options", "SAMEORIGIN")
 			w.Header().Set("x-content-type-options", "nosniff")
 			w.Header().Set("x-xss-protection", "1; mode=block")
-			renderFile(w, s.assets, s.config.HTTPBasePath, "/static/index.html")
+			renderFile(w, s.assets, s.config.HTTPBasePath, s.config.NetworkName, "/static/index.html")
 			return
 		})
 
@@ -105,7 +105,7 @@ func (s *Server) initRoutes() {
 		// can be resolved
 		r.HandleFunc("/static/static/js/manifest.{blob}.js", func(w http.ResponseWriter, req *http.Request) {
 			blob := chi.URLParam(req, "blob")
-			if err := renderFile(w, s.assets, s.config.HTTPBasePath, "/static/static/js/manifest."+blob+".js"); err != nil {
+			if err := renderFile(w, s.assets, s.config.HTTPBasePath, s.config.NetworkName, "/static/static/js/manifest."+blob+".js"); err != nil {
 				fmt.Println(err)
 			}
 		})
@@ -154,7 +154,7 @@ func staticHandler(fs http.FileSystem, prefix string) http.HandlerFunc {
 }
 
 // renderFile renders a file using a template with some variables.
-func renderFile(w http.ResponseWriter, fs http.FileSystem, baseURL, path string) error {
+func renderFile(w http.ResponseWriter, fs http.FileSystem, baseURL, networkName, path string) error {
 	file, err := fs.Open(path)
 	if err != nil {
 		// could not open file
@@ -184,7 +184,8 @@ func renderFile(w http.ResponseWriter, fs http.FileSystem, baseURL, path string)
 	w.Header().Set("Content-Type", contentType+"; charset=utf-8")
 
 	data := map[string]interface{}{
-		"BaseURL": baseURL,
+		"BaseURL":     baseURL,
+		"NetworkName": networkName,
 	}
 
 	err = tpl.Execute(w, data)

--- a/ui/index.html
+++ b/ui/index.html
@@ -11,6 +11,7 @@ Everything fancy that is happening in here. -->
 
   <!-- define variables that will be filled in by the backend -->
   <meta name="base" content="{{ .BaseURL }}">
+  <meta name="network" content="{{ .NetworkName }}">
 
   <!-- generated code and stylesheets will be inserted here -->
   <% for (var chunk of webpack.chunks) {

--- a/ui/src/store/index.js
+++ b/ui/src/store/index.js
@@ -11,6 +11,9 @@ const state = {
     .querySelector('meta[name="base"]')
     .getAttribute("content")
     .replace(/\/$/, ''), // remove trailing slash
+  networkName: document
+    .querySelector('meta[name="network"]')
+    .getAttribute("content"),
   jwt: '',
   user: {
     id: 0,

--- a/ui/src/views/Auth.vue
+++ b/ui/src/views/Auth.vue
@@ -5,7 +5,7 @@
         <div class="auth-container">
             <div class="branding">
                 <img src="@/assets/img/klink-logo-web.svg" alt="Klink logo">
-                <div class="platform">ICSD Network Registry</div>
+                <div class="platform">{{ $store.state.networkName }}</div>
             </div>
             <router-view></router-view>
         </div>
@@ -20,7 +20,8 @@
   bottom: 0;
   min-width: 100%;
   min-height: 100%;
-  background: linear-gradient(rgba(0, 144, 255, 0.85), rgba(0, 144, 255, 0.85)), url(//test.klink.asia/images/land.jpg);
+  background: linear-gradient(rgba(0, 144, 255, 0.85), rgba(0, 144, 255, 0.85)),
+    url(//test.klink.asia/images/land.jpg);
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
@@ -54,7 +55,7 @@
 
 .form-auth {
   padding: 30px;
-  box-shadow: rgba(0,0,0,0.2) 0px 0px 20px;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 0px 20px;
   border: none;
   border-radius: 3px;
   background: rgba(255, 255, 255, 1);
@@ -88,3 +89,4 @@
   }
 }
 </style>
+


### PR DESCRIPTION
This PR allows to make the instance name configurable by passing the `--name` flag, or the `REGISTRY_NAME` env variable.