### PR TITLE
Add database connection check

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -75,7 +75,7 @@ func PingWithRetry(db sqlx.DB) error {
 		}
 
 		log.Println("Trying again to contact the database host...")
-		time.Sleep(1 * time.Second)
+		time.Sleep(time.Duration(index+1) * time.Second)
 	}
 
 	return err

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -20,7 +20,7 @@ type Database struct {
 func NewDatabase(dsn string) (*Database, error) {
 	db, err := sqlx.Open("mysql", dsn)
 
-	err = PingWithRetry(*db)
+	err = PingWithRetry(*db, 5)
 
 	if err != nil {
 		db.Close()
@@ -62,8 +62,7 @@ func (db Database) IsNotFound(err error) bool {
 }
 
 // PingWithRetry tries to Ping the connection for a predefined number of attempts before failing
-func PingWithRetry(db sqlx.DB) error {
-	attempts := 3
+func PingWithRetry(db sqlx.DB, attempts int) error {
 	var err error
 	err = nil
 

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"database/sql"
+	"log"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -18,6 +19,13 @@ type Database struct {
 // NewDatabase returns a new MySQL database
 func NewDatabase(dsn string) (*Database, error) {
 	db, err := sqlx.Open("mysql", dsn)
+
+	err = PingWithRetry(*db)
+
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
 
 	// Solve the problem of silently dying idle connections
 	db.SetConnMaxLifetime(time.Second)
@@ -51,4 +59,24 @@ type PermissionRow struct {
 // found.
 func (db Database) IsNotFound(err error) bool {
 	return err == sql.ErrNoRows
+}
+
+// PingWithRetry tries to Ping the connection for a predefined number of attempts before failing
+func PingWithRetry(db sqlx.DB) error {
+	attempts := 3
+	var err error
+	err = nil
+
+	for index := 0; index < attempts; index++ {
+		err = db.Ping()
+
+		if err == nil {
+			return nil
+		}
+
+		log.Println("Trying again to contact the database host...")
+		time.Sleep(1 * time.Second)
+	}
+
+	return err
 }

--- a/klinkregistry/cmd/migrate.go
+++ b/klinkregistry/cmd/migrate.go
@@ -84,6 +84,7 @@ func migrate(config *klinkregistry.Config, command string) error {
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		log.Printf("Error opening connection to database: %s", err.Error())
+		panic(err)
 	}
 
 	migrator, err := mysql.GetMigrator(db, fs, migrationPathInFs)

--- a/klinkregistry/cmd/server.go
+++ b/klinkregistry/cmd/server.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	// DefaultPermissions contains the default permissions handled by the registry
 	DefaultPermissions = []string{
 		"data-add",
 		"data-edit",
@@ -75,6 +76,7 @@ configuration by registrants.`,
 		db, err := mysql.NewDatabase(dsn)
 		if err != nil {
 			log.Printf("Error creating Database: %s", err.Error())
+			panic(err)
 		}
 
 		// try to migrate to latest database revision


### PR DESCRIPTION
This pull request add the connection test when creating a new database and before failing attempts to connect for 3 times with a 1 second delay. This is useful in case the registry is started by Docker and the MySQL database is not yet ready